### PR TITLE
eslint fixes, обработка текста useHotkey хуком, интуитивное выделение слайда

### DIFF
--- a/src/components/UI/LeftBar.tsx
+++ b/src/components/UI/LeftBar.tsx
@@ -44,7 +44,7 @@ const LeftBar = () => {
       }
       else {
         setActiveSlideId(slide.id)
-        slides.map((s) => updateSlide({ slideId: s.id, selected: false }))
+        slides.map((s) => updateSlide({ slideId: s.id, selected: s.id === slide.id }))
       }
     }
   }

--- a/src/components/UI/MenuSections/SectionImages.tsx
+++ b/src/components/UI/MenuSections/SectionImages.tsx
@@ -14,7 +14,7 @@ const SectionImages = () => {
       return
     }
     FileHandler.ImportImage(file).then((base64) => {
-      let image = document.createElement('img');
+      const image = document.createElement('img');
       image.addEventListener('load', () => {
         importImage({ slideId: slideId, data: base64, width: image.width, height: image.height })
       });

--- a/src/hooks/useHotkey.ts
+++ b/src/hooks/useHotkey.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react"
 
-function useHotkey(data: {hotkey: string, callback: () => void}) {
+function useHotkey(data: {hotkey: string, callback: (event: KeyboardEvent) => void}) {
   // Разделяет строку по первому '+' после конца слова
   const hotkeyArray = Array.from(new Set(
     data.hotkey.toLocaleLowerCase().replace(/\s+/g, "").split(/\b\+/g)
@@ -17,6 +17,9 @@ function useHotkey(data: {hotkey: string, callback: () => void}) {
 
   const isSameHotkeys = (event: KeyboardEvent): boolean => {
     const activeKeys = getActiveKeysArray(event)
+    if (hotkeyArray.length === 1 && hotkeyArray[0] === "*") {
+      return true
+    }
     return hotkeyArray.length === activeKeys.length && 
       hotkeyArray.every((key) => activeKeys.includes(key))
   }
@@ -24,7 +27,7 @@ function useHotkey(data: {hotkey: string, callback: () => void}) {
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if (isSameHotkeys(event)) {
-        data.callback()
+        data.callback(event)
       }
     }
 

--- a/src/services/FileHandler.ts
+++ b/src/services/FileHandler.ts
@@ -1,11 +1,10 @@
-// @ts-ignore
 import html2pdf from "html2pdf.js"
 import PDFSlide from "../components/Slide/PdfSlide.tsx";
 import { renderToStaticMarkup } from "react-dom/server"
 import { SlideInfo } from "../models/types.ts";
 
 const pdfMargin = 0
-const pdfWidth =963
+const pdfWidth  = 963
 const pdfHeight = 543
 class FileHandler {
   private jsonFileType: string = '.json'
@@ -39,18 +38,16 @@ class FileHandler {
 
   public ExportPdf(slides: SlideInfo[], filename: string) {
     let result: string = ""
-    for (let slide of slides) {
+    for (const slide of slides) {
       result += renderToStaticMarkup(PDFSlide(slide))
     }
-    let opt = {
+    const opt = {
       margin: pdfMargin,
       filename:     filename + '.pdf',
       jsPDF:        { format: [pdfWidth, (pdfHeight - pdfMargin)*slides.length], orientation: "p"}
     };
 
-    console.log(result)
     html2pdf().from(result).set(opt).save()
-    console.log("asdasd")
   }
 
   private GenerateJsonFilename(filename: string): string {

--- a/src/store/reducers/historyReducer.ts
+++ b/src/store/reducers/historyReducer.ts
@@ -23,7 +23,7 @@ const historyReducer = createReducer(initialHistoryState, {
   [pushHistoryState.type]: (state, action: typeof pushHistoryState.actionInstance) => {
     return {...state, history: [...state.history, action.payload], currentIndex: state.currentIndex + 1}
   },
-  [clearHistoryAfterIndex.type]: (state, _) => {
+  [clearHistoryAfterIndex.type]: (state) => {
     const newHistory = [...state.history];
     newHistory.length = state.currentIndex + 1
     return {...state, history: newHistory}

--- a/src/utils/TextKeyHandler.ts
+++ b/src/utils/TextKeyHandler.ts
@@ -1,3 +1,4 @@
+import useHotkey from '../hooks/useHotkey'
 import { useAppSelector } from '../hooks/redux'
 import { SlideObjectType, TextObject } from '../models/types'
 import { usePresentationActions } from '../hooks/redux'
@@ -35,7 +36,7 @@ function textKeyHandler() {
     }
   }
 
-  window.onkeydown = (event: KeyboardEvent) => {
+  const mapKeyToFunc = (event: KeyboardEvent) => {
     if (document.activeElement?.tagName === "INPUT") return;
 
     switch (event.key) {
@@ -58,6 +59,8 @@ function textKeyHandler() {
       }
     }
   }
+
+  useHotkey({hotkey: "*", callback: (e) => mapKeyToFunc(e)})
 }
 
 export default textKeyHandler

--- a/src/utils/TextKeyHandler.ts
+++ b/src/utils/TextKeyHandler.ts
@@ -11,7 +11,7 @@ function textKeyHandler() {
     (state) => state.interfaceReducer.activeSlideId,
   )
 
-  let activeSlide = slides.find((s) => s.id === activeSlideId)
+  const activeSlide = slides.find((s) => s.id === activeSlideId)
 
   const selectedText = activeSlide?.slide.filter((obj) => obj.selected && obj.type === SlideObjectType.Text) ?? []
 


### PR DESCRIPTION
Исправил ошибки eslint. Единственный вопрос с html2pdf.js импортом, так как node_modules в игноре и нельзя через index.d.ts декларировать модуль.

Обработку нажатия клавиш для текста перенёс на кастомный useHotkey хук. Также useHotkey в качестве хоткея теперь может принимать "*" - т.е. любая клавиша.

Теперь, при нажатии ЛКМ на слайд, он будет автоматически выделяться (раньше требовалось нажимать с ctrl).